### PR TITLE
fix: getRewardsAmount doesn't fail in view call.

### DIFF
--- a/contracts/JetStakingV1.sol
+++ b/contracts/JetStakingV1.sol
@@ -740,6 +740,7 @@ contract JetStakingV1 is AdminControlled {
         view
         returns (uint256)
     {
+        if (lastUpdate == block.timestamp) return 0; // No more rewards since last update
         uint256 streamStart = streams[streamId].schedule.time[0];
         if (block.timestamp <= streamStart) return 0; // Stream didn't start
         uint256 streamEnd = streams[streamId].schedule.time[

--- a/test/unit/JetStakingV1.test.ts
+++ b/test/unit/JetStakingV1.test.ts
@@ -292,6 +292,14 @@ describe("JetStakingV1", function () {
         const {amount, } = await getEventLogs(tx.hash, constants.eventsABI.staked, 0)
         expect(amount).to.be.eq(amountStaked)
     })
+    it('should not release new rewards in the same block', async () => {
+        const amount = ethers.utils.parseUnits("1000", 18)
+        await auroraToken.connect(user1).approve(jet.address, amount)
+        await jet.connect(user1).stake(amount)
+        const touchedAt = await jet.touchedAt()
+        const rewards = await jet.getRewardsAmount(0, touchedAt)
+        expect(rewards.isZero()).to.be.eq(true)
+    })
     it('user stakes and never claims', async () => {
         const amountStaked1 = ethers.utils.parseUnits("1000", 18)
         await auroraToken.connect(user1).approve(jet.address, amountStaked1)


### PR DESCRIPTION
`_before()` has a [check](https://github.com/aurora-is-near/aurora-staking-contracts/blob/20dbf74ddd2f48d8a96a9947c6faea9ea6b91fde/contracts/JetStakingV1.sol#L930) which is not done in view calls when calling `getRewardsAmount` and `getLatestRewardPerShare`