### PR TITLE
refactor: optimize storage access and reduce the gas cost

### DIFF
--- a/contracts/JetStakingV1.sol
+++ b/contracts/JetStakingV1.sol
@@ -559,8 +559,8 @@ contract JetStakingV1 is AdminControlled {
     /// WARNING: rewards are not claimed during stake. Airdrop script must claim or
     /// only distribute to accounts without stake
     function stakeOnBehalfOfOtherUsers(
-        address[] memory accounts,
-        uint256[] memory amounts,
+        address[] calldata accounts,
+        uint256[] calldata amounts,
         uint256 batchAmount
     ) external pausable(1) onlyRole(AIRDROP_ROLE) {
         uint256 accountsLength = accounts.length;
@@ -617,7 +617,7 @@ contract JetStakingV1 is AdminControlled {
     /// @dev moves a set of stream Id rewards to pending.
     /// Allows user to select stream ids to claim from UI.
     /// @param streamIds stream indexes
-    function batchMoveRewardsToPending(uint256[] memory streamIds)
+    function batchMoveRewardsToPending(uint256[] calldata streamIds)
         external
         pausable(1)
     {
@@ -650,7 +650,7 @@ contract JetStakingV1 is AdminControlled {
 
     /// @dev Claim all stream rewards on behalf of other users.
     /// @param accounts the user account addresses.
-    function claimAllOnBehalfOfOtherUsers(address[] memory accounts)
+    function claimAllOnBehalfOfOtherUsers(address[] calldata accounts)
         external
         pausable(1)
         onlyRole(CLAIM_ROLE)
@@ -667,7 +667,7 @@ contract JetStakingV1 is AdminControlled {
     /// @param streamIds to claim.
     function batchClaimOnBehalfOfAnotherUser(
         address account,
-        uint256[] memory streamIds
+        uint256[] calldata streamIds
     ) external pausable(1) onlyRole(CLAIM_ROLE) {
         _before();
         _batchClaimRewards(account, streamIds);
@@ -676,8 +676,8 @@ contract JetStakingV1 is AdminControlled {
     /// @dev Claim all stream rewards on behalf of other users.
     /// @param accounts the user account addresses.
     function batchClaimOnBehalfOfOtherUsers(
-        address[] memory accounts,
-        uint256[] memory streamIds
+        address[] calldata accounts,
+        uint256[] calldata streamIds
     ) external pausable(1) onlyRole(CLAIM_ROLE) {
         _before();
         uint256 accountsLength = accounts.length;
@@ -730,7 +730,7 @@ contract JetStakingV1 is AdminControlled {
     /// @dev withdraw a set of stream Ids.
     /// Allows user to select stream ids to withdraw from UI.
     /// @param streamIds to withdraw.
-    function batchWithdraw(uint256[] memory streamIds) external pausable(1) {
+    function batchWithdraw(uint256[] calldata streamIds) external pausable(1) {
         User storage userAccount = users[msg.sender];
         for (uint256 i = 0; i < streamIds.length; i++) {
             if (
@@ -1080,7 +1080,7 @@ contract JetStakingV1 is AdminControlled {
     /// `_before` must be called before to update the streams rps.
     /// @param account the user account address.
     /// @param streamIds to claim.
-    function _batchClaimRewards(address account, uint256[] memory streamIds)
+    function _batchClaimRewards(address account, uint256[] calldata streamIds)
         internal
     {
         for (uint256 i = 0; i < streamIds.length; i++) {


### PR DESCRIPTION
- Before
```bash
Deploying 20 streams...
User1 stake 1st time (without _before): 324813 gas
User1 stake 2nd time (init _before + init rps): 1632695 gas
User1 stake 3rd time: 948695 gas
User2 stake 1st time (init rps): 1341995 gas
User2 stake 2nd time: 948695 gas
User2 stake 3rd time: 948695 gas
    ✓ estimageGas staking with multiple streams (5512ms)
Airdrop to 5 users with 4 streams.
Airdrop stake 1st time: 1152685 gas.
Claim all on behalf: 1476076 gas.
Airdrop add stake: 485785 gas.
Claim all on behalf of single user: 339110 gas.
```

- After
```bash
Deploying 20 streams...
User1 stake 1st time (without _before): 322736 gas
User1 stake 2nd time (init _before + init rps): 1620708 gas
User1 stake 3rd time: 936708 gas
User2 stake 1st time (init rps): 1330008 gas
User2 stake 2nd time: 936708 gas
User2 stake 3rd time: 936708 gas
    ✓ estimageGas staking with multiple streams (6854ms)
Airdrop to 5 users with 4 streams.
Airdrop stake 1st time: 1146963 gas.
Claim all on behalf: 1471895 gas.
Airdrop add stake: 480063 gas.
Claim all on behalf of single user: 336547 gas.
```