### PR TITLE
refactor: mark the implementation contract as `initialized` at the moment of the deployment

### DIFF
--- a/contracts/JetStakingV1.sol
+++ b/contracts/JetStakingV1.sol
@@ -138,6 +138,9 @@ contract JetStakingV1 is AdminControlled {
         _;
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() initializer {}
+
     /// @dev initialize the contract and deploys the first stream (AURORA)
     /// @notice By calling this function, the deployer of this contract must
     /// make sure that the AURORA reward amount was deposited to the treasury

--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -33,6 +33,9 @@ contract Treasury is ITreasury, AdminControlled {
         uint256 timestamp
     );
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() initializer {}
+
     /// @notice initializes ownable Treasury with list of managers and supported tokens
     /// @param _supportedTokens list of supported tokens
     function initialize(address[] memory _supportedTokens, uint256 _flags)


### PR DESCRIPTION
**Issue description**

No protection against calling initialize directly on the implementation contract followed by `selfdestruct` via `adminDelegateCall`. There should be some measure put in place to prevent this scenario from happening. 

**Recommendation:**

- One way is to add an empty constructor with initializer modifier (see [here](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract)). This will mark the implementation contract as initialized at the moment it is deployed, so no one else will be able to initialize it (and because no user will be assigned the admin role, no one will be able to use admin functions).

- Another option is to make it impossible to call initialize or adminDelegatecall directly on the implementation contract by adding onlyProxy modifier from UUPSUpgradeable to either of those functions, but the former solution is preferred.