### PR TITLE
fix: pausable check in `adminControlled`

### DIFF
--- a/contracts/AdminControlled.sol
+++ b/contracts/AdminControlled.sol
@@ -48,7 +48,8 @@ contract AdminControlled is UUPSUpgradeable, AccessControlUpgradeable {
     function adminPause(uint256 flags) external onlyRole(PAUSE_ROLE) {
         // pause role can pause the contract, however only default admin role can unpause
         require(
-            (paused & flags) != 0 || hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
+            (paused & flags) == paused ||
+                hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
             "ONLY_DEFAULT_ADMIN_CAN_UNPAUSE"
         );
         paused = flags;


### PR DESCRIPTION
The check for unpausing is incorrect.

The check that `(paused & flags) != 0` checks that there is at least one flag in common between the current and the new pause flags. Instead, there should be a check that no pause flags are removed.