### PR TITLE
fix: Return valid interval index when end = last index.

### DIFF
--- a/contracts/JetStakingV1.sol
+++ b/contracts/JetStakingV1.sol
@@ -942,7 +942,7 @@ contract JetStakingV1 is AdminControlled {
         }
         // find end index
         if (end == schedule.time[scheduleTimeLength - 1]) {
-            endIndex = scheduleTimeLength - 1;
+            endIndex = scheduleTimeLength - 2;
         } else {
             for (uint256 i = startIndex + 1; i < scheduleTimeLength; i++) {
                 if (end < schedule.time[i]) {
@@ -993,15 +993,10 @@ contract JetStakingV1 is AdminControlled {
                 schedule.reward[startIndex + 1] -
                 schedule.reward[endIndex];
             // Reward during the endIndex period
-            if (endIndex < schedule.time.length - 1) {
-                // If endIndex represents a non-empty interval
-                reward =
-                    schedule.reward[endIndex] -
-                    schedule.reward[endIndex + 1];
-                rewardScheduledAmount +=
-                    (reward * (end - schedule.time[endIndex])) /
-                    (schedule.time[endIndex + 1] - schedule.time[endIndex]);
-            }
+            reward = schedule.reward[endIndex] - schedule.reward[endIndex + 1];
+            rewardScheduledAmount +=
+                (reward * (end - schedule.time[endIndex])) /
+                (schedule.time[endIndex + 1] - schedule.time[endIndex]);
         }
         return rewardScheduledAmount;
     }

--- a/test/unit/JetStakingV1.test.ts
+++ b/test/unit/JetStakingV1.test.ts
@@ -573,7 +573,7 @@ describe("JetStakingV1", function () {
         expect(Math.round(parseFloat(ethers.utils.formatUnits(total)))).to.be.eq(parseFloat(expectedScheduleReward.toString()))
         expect(Math.round(parseFloat(ethers.utils.formatUnits(rewardPerShareAurora)))).to.be.eq(parseFloat(expectedScheduleReward.toString()))
         expect(startIndex.toNumber()).to.be.eq(0)
-        expect(endIndex.toNumber()).to.be.eq(4)
+        expect(endIndex.toNumber()).to.be.eq(3)
     })
     it('should schedule from 1 to 2 years', async () => {
         const { total, rewardPerShareAurora, scheduleCalculated } = await jet.before(scheduleTimes[1], scheduleTimes[2])
@@ -691,7 +691,7 @@ describe("JetStakingV1", function () {
         expect(scheduleCalculated.toNumber()).to.be.eq(expectedScheduledReward)
         expect(parseInt(ethers.utils.formatUnits(rewardPerShareAurora))).to.be.eq(expectedScheduledReward)
         expect(startIndex.toNumber()).to.be.eq(0)
-        expect(endIndex.toNumber()).to.be.eq(4)
+        expect(endIndex.toNumber()).to.be.eq(3)
     })
     it('should schedule from 200 to end (3 years)', async () => {
         const {total, rewardPerShareAurora, scheduleCalculated} = await jet.before(scheduleTimes[0] + 200 * oneDay, scheduleTimes[3])


### PR DESCRIPTION
1. startEndScheduleIndex may return an index that is not a valid index of an interval.

If end is equal to schedule.time[schedule.time.length - 1], this function returns schedule.time.length - 1 as endIndex, but the index of the last interval is schedule.time.length - 2. While rewardsSchedule function properly handles this out of range value, this may potentially break other code.
