### PR TITLE
test: added more edge cases tests for stake-unstake in the same block

### DIFF
--- a/test/unit/JetStakingV1.test.ts
+++ b/test/unit/JetStakingV1.test.ts
@@ -2685,7 +2685,6 @@ describe("JetStakingV1", function () {
         await jet.connect(user1).stake(amount)
         await network.provider.send("evm_mine", [startTime + oneYear])
         await auroraToken.connect(user2).approve(jet.address, amount)
-        await network.provider.send("evm_setAutomine", [false])
         // User2 stakes and unstakes in the same block: rounding up of shares increases the unstaked amount
         // by a dust value lower than 1 share's value.
         await jet.connect(user2).stake(amount)
@@ -2744,7 +2743,6 @@ describe("JetStakingV1", function () {
         await network.provider.send("evm_mine", [startTime + oneYear])
         // User2 stakes and unstakes in the same block: rounding up of shares increases the unstaked amount
         // by a dust value lower than 1 share's value.
-        await network.provider.send("evm_setAutomine", [false])
         const user2Amount = ethers.utils.parseUnits("2", 18) // 2 AURORA
         await auroraToken.connect(user2).approve(jet.address, user2Amount)
         await jet.connect(user2).stake(user2Amount)
@@ -2803,7 +2801,6 @@ describe("JetStakingV1", function () {
         await network.provider.send("evm_mine", [startTime + oneYear])
         // User2 stakes and unstakes in the same block: rounding up of shares increases the unstaked amount
         // by a dust value lower than 1 share's value.
-        await network.provider.send("evm_setAutomine", [false])
         const user2Amount = ethers.utils.parseUnits("0.5", 18) // 0.5 AURORA
         await auroraToken.connect(user2).approve(jet.address, user2Amount)
         await jet.connect(user2).stake(user2Amount)
@@ -2862,7 +2859,6 @@ describe("JetStakingV1", function () {
         await network.provider.send("evm_mine", [startTime + oneYear])
         // User2 stakes and unstakes in the same block: rounding up of shares increases the unstaked amount
         // by a dust value lower than 1 share's value.
-        await network.provider.send("evm_setAutomine", [false])
         const user2Amount = ethers.utils.parseUnits("5", 2) // 5 * 10^-16 AURORA
         await auroraToken.connect(user2).approve(jet.address, user2Amount)
         await jet.connect(user2).stake(user2Amount)


### PR DESCRIPTION
```bash
scenario #1 user 2 (stakes & unstakes) 50% of the total staked aurora 
user 1 staked amount: 1.0 AURORA
user 2 staked amount: 0.5 AURORA
User 1 shares 1000000000000000000 and User 2 shares is 9999999801
total shares are: 1000000009999999801
user2UnstakedAmount : 0.500000000035094257 AURORA 
oneShareValue: 0.000000000050000001 AURORA
The amount of the dust token is `0.000000000035094257` AURORA.

Scenario #2 user 2 (stakes & unstakes) 200% of the total staked aurora
user 1 staked amount: 1.0 AURORA
user 2 staked amount: 2.0 AURORA
User 1 shares 1000000000000000000 and User 2 shares is 39999999201
total shares are: 1000000039999999201
user2UnstakedAmount : 2.000000000040377291 AURORA 
oneShareValue: 0.00000000005 AURORA

Scenario #3 user stakes (very small fraction of AURORA) 
# & unstakes (in the same block) where the total staked
# AURORA is very small 1^-16 AURORA
user 1 staked amount: 0.0000000000000001 AURORA
user 2 staked amount: 0.0000000000000001 AURORA
User 1 shares 100 and User 2 shares is 1
total shares are: 101
user2UnstakedAmount : 495048.210731148132893315 AURORA 
oneShareValue: 495049.504950495049504952 AURORA

Scenario #4 user stakes & unstake very small fraction 
# of AURORA in the same block where it is very small
# compared to the total staked aurora
user 1 staked amount: 1.0 AURORA
user 2 staked amount: 0.0000000000000005 AURORA
User 1 shares 1000000000000000000 and User 2 shares is 1
total shares are: 1000000000000000001
user2UnstakedAmount : 0.000000000049999871 AURORA 
oneShareValue: 0.000000000050000001 AURORA
```