### PR TITLE
chore: slither annotations

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,4 +23,4 @@ jobs:
         uses: actions/checkout@v2
       - run: pip install slither-analyzer==0.8.2
       - run: yarn install
-      - run: slither . --filter-paths "node_modules|testing" --exclude timestamp,reentrancy-no-eth,reentrancy-events,reentrancy-benign || true
+      - run: slither . --filter-paths "node_modules|testing" --exclude timestamp,solc-version,naming-convention,assembly-usage

--- a/contracts/AdminControlled.sol
+++ b/contracts/AdminControlled.sol
@@ -100,6 +100,7 @@ contract AdminControlled is UUPSUpgradeable, AccessControlUpgradeable {
         returns (bytes memory)
     {
         require(target != address(0), "ZERO_ADDRESS");
+        // slither-disable-next-line controlled-delegatecall,low-level-calls
         (bool success, bytes memory rdata) = target.delegatecall(data);
         require(success);
         return rdata;


### PR DESCRIPTION
Add annotations to disable Slither false-positives and enable the Slither check to fail on new errors.

`TODO` items require extra input/fixes.