### PR TITLE
Use public runners

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -10,7 +10,7 @@ name: jet-contracts
 jobs:
   tests:
     name: Static Analysis (Check This Report Before Merging)
-    runs-on: [self-hosted, light]
+    runs-on: ubuntu-latest
     env:
       INFURA_KEY: ${{secrets.INFURA_KEY}}
       ETHERSCAN_API_KEY: ${{secrets.ETHERSCAN_API_KEY}}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -21,6 +21,6 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - run: pip install slither-analyzer==0.8.2
+      - run: pip install slither-analyzer==0.11.3
       - run: yarn install
       - run: slither . --filter-paths "node_modules|testing" --exclude timestamp,reentrancy-no-eth,reentrancy-events,reentrancy-benign || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ name: jet-contracts
 jobs:
   tests:
     name: Unit Testing
-    runs-on: [self-hosted, light]
+    runs-on: ubuntu-latest
     env:
       INFURA_KEY: ${{secrets.INFURA_KEY}}
       ETHERSCAN_API_KEY: ${{secrets.ETHERSCAN_API_KEY}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow configurations to use GitHub-hosted runners for static analysis and unit testing jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->